### PR TITLE
fix(cmake): find Mlite5 using pkgconfig rather than a non-existing CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,13 @@ project(sensorlogd
     DESCRIPTION "A sensor logger daemon for AsteroidOS oriented towards health tracking"
 )
 
-find_package(ECM REQUIRED NO_MODULE)
-find_package(AsteroidApp REQUIRED)
-
-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ASTEROID_MODULE_PATH})
+find_package(PkgConfig)
 
 include(FeatureSummary)
 include(GNUInstallDirs)
-include(ECMFindQmlModule)
-include(ECMGeneratePkgConfigFile)
-include(AsteroidCMakeSettings)
-
-include(AsteroidCMakeSettings)
 
 find_package(Qt5 COMPONENTS Core DBus Qml Sensors REQUIRED)
-find_package(Mlite5 MODULE REQUIRED)
+pkg_check_modules(mlite5 REQUIRED Mlite5)
 
 add_subdirectory(daemon)
 add_subdirectory(qmlplugin)

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -13,7 +13,14 @@ add_executable(sensorlogd
 )
 set_target_properties(sensorlogd PROPERTIES AUTOMOC ON)
 #add_compile_definitions(Q_DECLARE_PRIVATE_SUPPORTS_UNIQUE_PTR=${Q_DECLARE_PRIVATE_SUPPORTS_UNIQUE_PTR})
-target_link_libraries(sensorlogd PRIVATE Qt5::Core Qt5::DBus Qt5::Qml Qt5::Sensors Mlite5::Mlite5)
+target_link_libraries(sensorlogd PRIVATE
+    Qt5::Core
+    Qt5::DBus
+    Qt5::Qml
+    Qt5::Sensors
+    ${mlite5_LIBRARIES}
+)
+target_include_directories(sensorlogd PRIVATE ${mlite5_INCLUDE_DIRS})
 install(TARGETS sensorlogd DESTINATION bin)
 install(FILES systemd/asteroid-sensorlogd.service
 		DESTINATION /usr/lib/systemd/user)

--- a/qmlplugin/CMakeLists.txt
+++ b/qmlplugin/CMakeLists.txt
@@ -16,8 +16,12 @@ add_library(
     ../common.h
 )
 
-target_link_libraries(sensorlogdqmlplugin
-	Qt5::Qml Qt5::Quick Qt5::DBus Qt5::Sensors
+target_link_libraries(
+    sensorlogdqmlplugin
+    Qt5::Qml
+    Qt5::Quick
+    Qt5::DBus
+    Qt5::Sensors
 )
 
 install(TARGETS sensorlogdqmlplugin


### PR DESCRIPTION
qml-asteroid recently got rid of it's `FindMlite5.cmake` module and we
don't need it anyway.